### PR TITLE
Ensure correct section type for VPN zone detection

### DIFF
--- a/usr/lib/lua/luci/controller/dn11.lua
+++ b/usr/lib/lua/luci/controller/dn11.lua
@@ -116,9 +116,12 @@ function add_peer()
     local zones = uci:get_all("firewall")
     local vpn_zone
     for name, zone in pairs(zones) do
-        if zone.name == 'vpn' then
-            vpn_zone = name
-            break
+        -- avoid other type of section be used incorrectly
+        if zone['.type'] == "zone" then
+            if zone.name == 'vpn' then
+                vpn_zone = name
+                break
+            end
         end
     end
     if vpn_zone then


### PR DESCRIPTION
修复了device可能被写进具有同名区域的forward规则中的问题

我在我的脚本中使用了基本相同的代码，然后他把这个device写到包含这个区域的forward规则里去了，虽然很莫名其妙但是判断一下.type的内容就能保证你遍历的真的是zone